### PR TITLE
Templates with ports for Tad, Silicoin, Dogechia

### DIFF
--- a/blockchain/tad.json.template
+++ b/blockchain/tad.json.template
@@ -1,0 +1,20 @@
+{
+    "Binary Name": "tad",
+    "Folder Name": ".tad",
+    "Currency Symbol": "TAD",
+    "Minor Currency Symbol": "mojo",
+    "Net": "mainnet",
+    
+    "Block Rewards": 2.0,
+    "Blocks Per 10 Minutes": 32.0,
+
+    "Online Config": true,
+    
+    "Ports": {
+        "harvester": 4458,
+        "farmer": 4457,
+        "fullNode": 4555,
+        "wallet": 4456,
+        "daemon": 4400
+      }
+}

--- a/blockchain/tsit.json.template
+++ b/blockchain/tsit.json.template
@@ -1,0 +1,20 @@
+{
+    "Binary Name": "silicoin",
+    "Folder Name": ".silicoin",
+    "Currency Symbol": "tSIT",
+    "Minor Currency Symbol": "mojo",
+    "Net": "testnet",
+    
+    "Block Rewards": 2.0,
+    "Blocks Per 10 Minutes": 32.0,
+    
+    "Online Config": true,
+    
+    "Ports": {
+        "harvester": 10560,
+        "farmer": 10559,
+        "fullNode": 10555,
+        "wallet": 10256,
+        "daemon": 56401
+      }
+}

--- a/blockchain/xdg.json.template
+++ b/blockchain/xdg.json.template
@@ -1,0 +1,19 @@
+{
+    "Binary Name": "dogechia",
+    "Currency Symbol": "XDG",
+    "Minor Currency Symbol": "mojo",
+    "Net": "mainnet",
+    
+    "Block Rewards": 2.0,
+    "Blocks Per 10 Minutes": 32.0,
+    
+    "Online Config": true,
+    
+    "Ports": {
+        "harvester": 6770,
+        "farmer": 16759,
+        "fullNode": 6769,
+        "wallet": 16761,
+        "daemon": 56669
+      }
+}


### PR DESCRIPTION
Hello!  So here are the three json templates I've been working on.  As we discussed, these are not currently fully functional - they will work for total plots, cold wallet balances and will confirm harvester and farming status, so they're not useless atm, but none of them show Skipped Blocks or Complete Subslots, and only the Chiadoge (XDG) one shows *any* log related values (it does show Longest Response Time and Missed Challenges).  If you are going to proceed to change the functionality to work through the rcp ports, though, you'll want these already filled out.